### PR TITLE
I fixed the macos bindings so that it actually works on macos not using rosetta.

### DIFF
--- a/Watcher.csproj
+++ b/Watcher.csproj
@@ -53,7 +53,7 @@
         <!-- The below should not need to be changed. -->
         <Sts2Path Condition="'$(Sts2Path)' == ''">$(SteamLibraryPath)/common/Slay the Spire 2</Sts2Path>
         <ModsPath Condition="'$(ModsPath)' == ''">$(Sts2Path)/SlayTheSpire2.app/Contents/MacOS/mods/</ModsPath>
-        <Sts2DataDir Condition="'$(Sts2DataDir)' == ''">$(Sts2Path)/SlayTheSpire2.app/Contents/Resources/data_sts2_macos_x86_64</Sts2DataDir>
+        <Sts2DataDir Condition="'$(Sts2DataDir)' == ''">$(Sts2Path)/SlayTheSpire2.app/Contents/Resources/data_sts2_macos_arm64</Sts2DataDir>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -76,7 +76,7 @@
             <Private>false</Private>
         </Reference>
 
-        <PackageReference Include="Alchyr.Sts2.BaseLib" Version="0.2.1" PrivateAssets="All" />
+        <PackageReference Include="Alchyr.Sts2.BaseLib" Version="0.2.1" PrivateAssets="All"/>
         <PackageReference Include="Alchyr.Sts2.ModAnalyzers" Version="0.0.9"/>
         <AdditionalFiles Include="Watcher/localization/**/*.json"/>
     </ItemGroup>


### PR DESCRIPTION
Very very small change plus here is a new release for mac without rosetta and arm64:
[Watcher.zip](https://github.com/user-attachments/files/26367596/Watcher.zip)
