### PR TITLE
Fix FlurryOfBlows draw from all piles

### DIFF
--- a/Code/Cards/Common/FlurryOfBlows.cs
+++ b/Code/Cards/Common/FlurryOfBlows.cs
@@ -27,7 +27,7 @@ public sealed class FlurryOfBlows : WatcherCardModel, IOnStanceChange
 
     public async Task OnStanceChange(PlayerChoiceContext ctx, Player player, WatcherStanceModel oldStance, WatcherStanceModel newStance)
     {
-        if (newStance.Owner != Owner && Pile?.Type != PileType.Discard) return;
+        if (newStance.Owner != Owner || Pile?.Type != PileType.Discard) return;
         await CardPileCmd.Add(this, PileType.Hand);
     }
 }


### PR DESCRIPTION
Just tested the mod and found this bug where Flurry Of Blows is draw from draw pile on Stance change when it should be only from discard.

Created Issue:
https://github.com/lamali292/WatcherMod/issues/34