### PR TITLE
:bug: Fix Duality logic to stack dexerity

### DIFF
--- a/Code/Powers/DualityPower.cs
+++ b/Code/Powers/DualityPower.cs
@@ -1,22 +1,27 @@
-﻿using BaseLib.Abstracts;
-using BaseLib.Extensions;
+using MegaCrit.Sts2.Core.Combat;
 using MegaCrit.Sts2.Core.Commands;
-using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Entities.Powers;
 using MegaCrit.Sts2.Core.GameActions.Multiplayer;
-using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Powers;
-using Watcher.Code.Extensions;
-using Watcher.Code.Relics;
+using Watcher.Code.Abstract;
 
 namespace Watcher.Code.Powers;
 
-public class DualityPower : CustomTemporaryPowerModel
+// Bookkeeping debuff for the Duality relic. Each stack represents one point of Dexterity granted
+// earlier in the turn that must be subtracted at turn end, making the relic's Dexterity gain temporary.
+public sealed class DualityPower : WatcherPowerModel
 {
-    protected override Func<PlayerChoiceContext, Creature, decimal, Creature?, CardModel?, bool, Task> ApplyPowerFunc =>
-        PowerCmd.Apply<DexterityPower>;
+    public override PowerType Type => PowerType.Debuff;
+    public override PowerStackType StackType => PowerStackType.Counter;
 
-    public override PowerModel InternallyAppliedPower => ModelDb.Power<DexterityPower>();
-    public override AbstractModel OriginModel => ModelDb.Relic<Duality>();
-    public override string CustomPackedIconPath => $"{Id.Entry.RemovePrefix().ToLowerInvariant()}.png".PowerImagePath();
-    public override string CustomBigIconPath => CustomPackedIconPath;
+    public override async Task AfterTurnEnd(PlayerChoiceContext choiceContext, CombatSide side)
+    {
+        // Only fire on the player's own turn end; Amount<=0 guards against stacking with no payload.
+        if (Owner.Player?.Creature.Side != side || Amount <= 0) return;
+
+        // Strip exactly the Dexterity granted by Duality this turn, then clean up so the next turn starts fresh.
+        await PowerCmd.Apply<DexterityPower>(choiceContext, Owner.Player.Creature, -Amount, Owner.Player.Creature, null);
+        Flash();
+        if (Owner.IsAlive) RemoveInternal();
+    }
 }

--- a/Code/Relics/Duality.cs
+++ b/Code/Relics/Duality.cs
@@ -3,6 +3,7 @@ using MegaCrit.Sts2.Core.Commands;
 using MegaCrit.Sts2.Core.Commands.Builders;
 using MegaCrit.Sts2.Core.Entities.Relics;
 using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Models.Powers;
 using Watcher.Code.Abstract;
 using Watcher.Code.Character;
 using Watcher.Code.Powers;
@@ -18,6 +19,8 @@ public sealed class Duality : WatcherRelicModel
     public override async Task AfterAttack(PlayerChoiceContext choiceContext, AttackCommand command)
     {
         if (command.Attacker != Owner.Creature) return;
+        // Pair each attack: +1 Dexterity now, +1 DualityPower stack to subtract that Dexterity at turn end.
+        await PowerCmd.Apply<DexterityPower>(choiceContext, Owner.Creature, 1, Owner.Creature, null);
         await PowerCmd.Apply<DualityPower>(choiceContext, Owner.Creature, 1, Owner.Creature, null, true);
     }
 }


### PR DESCRIPTION
The previous version just applied one dexterity at the start but incremented the dexterity down duality counter each attack. This change no longer uses the wrapper and just manually increments the two counters, which will fix the net dexterity down past one attack.