### PR TITLE
Update `LikeWater`: Give block earlier

### DIFF
--- a/Code/Powers/LikeWaterPower.cs
+++ b/Code/Powers/LikeWaterPower.cs
@@ -24,7 +24,7 @@ public class LikeWaterPower : WatcherPowerModel
     ];
 
 
-    public override async Task AfterSideTurnEnd(PlayerChoiceContext choiceContext, CombatSide side, IEnumerable<Creature> participants)
+    public override async Task BeforeSideTurnEndEarly(PlayerChoiceContext choiceContext, CombatSide side, IEnumerable<Creature> participants)
     {
         if (Owner.Player?.Creature.Side != side) return;
         var isInCalm = Owner.Player.IsInWatcherStance<CalmStance>();


### PR DESCRIPTION
With `AfterSideTurnEnd` you first take damage from status cards, then gain block from Like Water.

With `BeforeSideTurnEndEarly` it seems to match StS 1: block is given before in-hand status cards deal damage. Like Water + Orichalcum still gives block from both, also matching the original game.  

I should note that this is my first time working on a character, so I'm not fully certain which hooks to use. However, this is the hook used by the game's Plating, so it seems likely to be the correct choice. `AfterSideTurnEnd` also worked in my tests, but I assume there are cases where it won't be right as the XML doc for Plating explicitly says:

> We do this in early so that it triggers before end-of-turn damage effects.

Tested with Burn, Infection, Wither and against the Knowledge Demon's damage effects and together with Orichalcum, Fake Orichalcum, Gorget and Plated Armor.